### PR TITLE
Update legends.html

### DIFF
--- a/legends.html
+++ b/legends.html
@@ -94,11 +94,11 @@
                         ↪ No Parry (Except Gehrman)
                       <br/><br/><strong>Demon's Souls</strong><br/><br/>
                       <h5>• +0 Weapons</h5>
-                        ↪ No Buffs (except Maneaters)<br/><br/>
+                        ↪ No Buffs<br/><br/>
                       <h5>• No Roll/Block/Parry</h5>
                         ↪ Broken Weapons (Except False King Allant)<br/>
-                        ↪ No Soul Form (Except Phalanx, False King Allant)<br/>
-                        ↪ No Rings (Except False King Allant)<br/><br/>
+                        ↪ No Soul Form (Except Phalanx)<br/>
+                        ↪ No Rings<br/><br/>
                       <h5>• No Sprint/Roll/Block/Parry</h5>
                         ↪ No Rings (Except False King Allant)<br/>
                         ↪ No Hit<br/></p>


### PR DESCRIPTION
Two more verified kills in DeSD:
- Maneaters, +0 Weapons No Buffs (https://www.youtube.com/watch?v=eQJB9zrAy04)
- False King Allant, No Roll/Block/Parry, No Rings, No Soul Form (https://www.youtube.com/watch?v=Vu7QMdJKkJ0)